### PR TITLE
Update code style for Silex 2

### DIFF
--- a/src/Knp/PaginatorProvider.php
+++ b/src/Knp/PaginatorProvider.php
@@ -26,7 +26,9 @@ class PaginatorProvider implements ServiceProviderInterface, EventListenerProvid
 {
     public function register(Container $app)
     {
-        $app['locale'] = 'en';
+        if (!isset($app['locale'])) {
+            $app['locale'] = 'en';
+        }
 
         if (!isset($app['twig'])) {
             $app->register(new TwigServiceProvider());

--- a/src/Knp/PaginatorProvider.php
+++ b/src/Knp/PaginatorProvider.php
@@ -11,17 +11,18 @@ use Knp\Component\Pager\Event\Subscriber\Sortable\SortableSubscriber;
 use Knp\Component\Pager\Paginator;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use Silex\Api\BootableProviderInterface;
+use Silex\Api\EventListenerProviderInterface;
 use Silex\Application;
 use Silex\Provider\TranslationServiceProvider;
 use Silex\Provider\TwigServiceProvider;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Class PaginatorProvider
  * @package Silex\Knp
  */
-class PaginatorProvider implements ServiceProviderInterface, BootableProviderInterface
+class PaginatorProvider implements ServiceProviderInterface, EventListenerProviderInterface
 {
     public function register(Container $app)
     {
@@ -125,16 +126,13 @@ class PaginatorProvider implements ServiceProviderInterface, BootableProviderInt
         };
     }
 
-    /**
-     * @param Application $app
-     */
-    public function boot(Application $app)
+    public function subscribe(Container $app, EventDispatcherInterface $dispatcher)
     {
-        $app['dispatcher']->addSubscriber($app['knp_paginator.pagination_subscriber']);
-        $app['dispatcher']->addSubscriber($app['knp_paginator.sortable_subscriber']);
-        $app['dispatcher']->addSubscriber($app['knp_paginator.filtration_subscriber']);
-        $app['dispatcher']->addSubscriber($app['knp_paginator.sliding_pagination_subscriber']);
-        $app['dispatcher']->addListener(
+        $dispatcher->addSubscriber($app['knp_paginator.pagination_subscriber']);
+        $dispatcher->addSubscriber($app['knp_paginator.sortable_subscriber']);
+        $dispatcher->addSubscriber($app['knp_paginator.filtration_subscriber']);
+        $dispatcher->addSubscriber($app['knp_paginator.sliding_pagination_subscriber']);
+        $dispatcher->addListener(
             KernelEvents::REQUEST,
             [$app['knp_paginator.sliding_pagination_subscriber'], 'onKernelRequest']
         );

--- a/src/Knp/PaginatorProvider.php
+++ b/src/Knp/PaginatorProvider.php
@@ -38,7 +38,7 @@ class PaginatorProvider implements ServiceProviderInterface, EventListenerProvid
             $app->register(new TranslationServiceProvider());
         }
 
-        $app['twig'] = $app->extend('twig', function (\Twig_Environment $twig) use ($app) {
+        $app->extend('twig', function (\Twig_Environment $twig) use ($app) {
             $processor = new Processor($app['url_generator'], $app['translator']);
 
             $twig->addExtension(new PaginationExtension($processor));


### PR DESCRIPTION
The service provider was updated to work with Silex 2 and Pimple 2/3, but it didn't use much of the good style introduced in the newer versions.